### PR TITLE
fix(run module): Allow multiple file on a input

### DIFF
--- a/src/components/run/module-spec/ModuleSpecComponent.js
+++ b/src/components/run/module-spec/ModuleSpecComponent.js
@@ -112,7 +112,7 @@ class ModuleSpecComponent extends React.Component {
               type={inputType}
               name={input.name}
               id={input.name}
-              multiple={multipleFile}
+              inputProps={{ multiple: multipleFile }}
               required
             />
           ) : (


### PR DESCRIPTION
Due to the implementation of material-ui, now the multiple input option needs to be set through the inputProps.